### PR TITLE
Fix repeated RNG seed calls

### DIFF
--- a/example_matlab.m
+++ b/example_matlab.m
@@ -21,6 +21,8 @@ close all;
 
 addpath('lib');
 
+rng('shuffle');
+
 %% Dataset info %%%
 im_path='data/';
 image_names={'input_0.png','input_1.png','input_2.png'};

--- a/example_octave.m
+++ b/example_octave.m
@@ -63,7 +63,7 @@ fprintf('%d tracks between the three images.\n',size(Corresp,2));
 
 
 %% A C RANSAC with Orthographic model %%%
-[inliers,Sol,ransac_th]=AC_RANSAC_Orthographic(Corresp,CalM,imsize,[],[],true);
+[inliers,Sol,ransac_th]=AC_RANSAC_Orthographic(Corresp,CalM,imsize);
 fprintf('%d inliers were found by AC-RANSAC.\n',length(inliers));
 
 %% Orthographic model with all inliers %%%

--- a/lib/AC_RANSAC_Orthographic.m
+++ b/lib/AC_RANSAC_Orthographic.m
@@ -1,4 +1,4 @@
-function [inliers,Sol,ransac_th]=AC_RANSAC_Orthographic(Corresp,CalM,imsize,NFA_th,max_it,Octave)
+function [inliers,Sol,ransac_th]=AC_RANSAC_Orthographic(Corresp,CalM,imsize,NFA_th,max_it)
 %AC_RANSAC_ORTHOGRAPHIC A Contrario RANSAC applied to the Scaled Orthographic
 % Model for finding the inlier tracks between three orthographic views.
 %
@@ -18,8 +18,6 @@ function [inliers,Sol,ransac_th]=AC_RANSAC_Orthographic(Corresp,CalM,imsize,NFA_
 %  NFA_th     - threshold for NFA that establishes the validity of a
 %               model (1 by default).
 %  max_it     - maximum number of iterations for ransac (100 by default).
-%  Octave     - true if Octave is beign used, false if Matlab is used instead.
-%               Default value is false.
 %
 %  Output arguments:
 %  inliers    - indexes indicating the final inliers in Data.
@@ -53,9 +51,6 @@ end
 if nargin<5 || isempty(NFA_th)
     NFA_th=1;
 end
-if nargin<6 || isempty(Octave)
-    Octave=false;
-end
 
 N=size(Corresp,2);
 n_sample=4; % minimal number of matching points for pose estimation
@@ -71,13 +66,6 @@ ransac_th=inf;        % ransac threshold
 it=0; max_old=max_it;
 while it<max_it
     it=it+1;
-    
-    % pick random sample of n_sample data
-    if Octave
-      rand('seed',it);
-    else
-      rng(it);
-    end
     sample=my_randsample(N,n_sample);
     
     % compute orientations with Orthographic model from this sample


### PR DESCRIPTION
The seed of the RNG must not be called multiple times, only once before calls to rand.
Setting the seed is not useful in Octave, which has a sane default.
As a side effect, the file AC_RANSAC_Orthographic.m does not need to distinguish between Octave and Matlab anymore.

Verified with Matlab, please check Octave run.